### PR TITLE
Feature/fh 30 calcom

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@calcom/web",
-  "version": "3.7.9-c",
+  "version": "3.7.10",
   "private": true,
   "scripts": {
     "analyze": "ANALYZE=true next build",

--- a/apps/web/pages/api/webhook/funnelhub/add-member-to-team.ts
+++ b/apps/web/pages/api/webhook/funnelhub/add-member-to-team.ts
@@ -1,0 +1,62 @@
+/* eslint-disable turbo/no-undeclared-env-vars */
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import prisma from "@calcom/prisma";
+
+export const AddMemberToTeamSchema = z.object({
+  funnelHubUserId: z.string(),
+  workspaceId: z.string(),
+  role: z.enum(["MEMBER", "ADMIN", "OWNER"]).default("MEMBER"),
+});
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const funnelHubToken = process.env.FUNNELHUB_API_TOKEN;
+  const funnelHubApiToken = req.headers["funnehub-calendar-token"];
+  const isFunnelHubOrigin = funnelHubToken === funnelHubApiToken;
+
+  if (req.method.toLowerCase() !== "post") return res.status(404).json({ message: "method not allowed" });
+
+  if (!isFunnelHubOrigin) return res.status(401).json({ message: "Invalid funnelhub api token " });
+
+  const userValidation = AddMemberToTeamSchema.safeParse(req.body);
+
+  if (!userValidation.success)
+    return res.status(422).json({ errors: userValidation.error.flatten().fieldErrors });
+
+  const { funnelHubUserId, workspaceId, role } = userValidation.data;
+  const user = await prisma.user.findFirst({ where: { funnelHubUserId } });
+  if (!user) res.status(404).json({ errors: ["User not found"] });
+  const team = await prisma.team.findFirst({ where: { funnelhubWorkspaceId: workspaceId } });
+  if (!team) res.status(404).json({ errors: ["Team not found"] });
+
+  const memberShip = await prisma.membership.findFirst({
+    where: {
+      userId: user?.id as number,
+      teamId: team?.id as number,
+    },
+  });
+
+  if (!memberShip) {
+    await prisma.membership.create({
+      data: {
+        userId: user?.id as number,
+        teamId: team?.id as number,
+        role,
+      },
+    });
+  } else {
+    await prisma.membership.update({
+      where: {
+        id: memberShip.id,
+      },
+      data: {
+        userId: user?.id as number,
+        teamId: team?.id as number,
+        role,
+      },
+    });
+  }
+
+  return res.status(200).json({ message: "User created successfully!" });
+}

--- a/apps/web/pages/api/webhook/funnelhub/add-member-to-team.ts
+++ b/apps/web/pages/api/webhook/funnelhub/add-member-to-team.ts
@@ -43,6 +43,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         userId: user?.id as number,
         teamId: team?.id as number,
         role,
+        accepted: true,
       },
     });
   } else {
@@ -54,6 +55,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         userId: user?.id as number,
         teamId: team?.id as number,
         role,
+        accepted: true,
       },
     });
   }

--- a/apps/web/pages/api/webhook/funnelhub/funnelhub-signup.ts
+++ b/apps/web/pages/api/webhook/funnelhub/funnelhub-signup.ts
@@ -1,0 +1,80 @@
+/* eslint-disable turbo/no-undeclared-env-vars */
+import crypto from "crypto";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import prisma from "@calcom/prisma";
+import { MembershipRole } from "@calcom/prisma/client";
+
+export const FunnelhubSignupSchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(3),
+  funnelHubUserId: z.string(),
+  workspaceId: z.string().optional(),
+  shouldNotCreateTeam: z.boolean().default(false),
+});
+
+const generateRandomString = (length: number) => {
+  return crypto
+    .randomBytes(Math.ceil(length / 2))
+    .toString("hex")
+    .slice(0, length);
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const funnelHubToken = process.env.FUNNELHUB_API_TOKEN;
+  const funnelHubApiToken = req.headers["funnehub-calendar-token"];
+  const isFunnelHubOrigin = funnelHubToken === funnelHubApiToken;
+  if (req.method.toLowerCase() !== "post") return res.status(404).json({ message: "method not allowed" });
+
+  if (!isFunnelHubOrigin) return res.status(401).json({ message: "Invalid funnelhub api token " });
+
+  const userValidation = FunnelhubSignupSchema.safeParse(req.body);
+
+  if (!userValidation.success)
+    return res.status(422).json({ errors: userValidation.error.flatten().fieldErrors });
+
+  const { email, name, funnelHubUserId, workspaceId, shouldNotCreateTeam } = userValidation.data;
+  const user = await prisma.user.create({
+    data: {
+      name,
+      email,
+      funnelHubUserId,
+      emailVerified: new Date(),
+      timeZone: "America/Sao_Paulo",
+      locale: "pt-BR",
+      username: `${name
+        .toLowerCase()
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .replace(/\s+/g, "-")}-${generateRandomString(5)}`,
+    },
+  });
+
+  if (shouldNotCreateTeam) {
+    return res.status(200).json({ message: "User created successfully!" });
+  }
+
+  const userTeam = await prisma.team.create({
+    data: {
+      name: `${name} time`,
+      slug: `${name
+        .toLowerCase()
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .replace(/\s+/g, "-")}-time-${generateRandomString(5)}`,
+      funnelhubWorkspaceId: workspaceId,
+      timeZone: "America/Sao_Paulo",
+    },
+  });
+
+  await prisma.membership.create({
+    data: {
+      teamId: userTeam.id,
+      userId: user.id,
+      role: MembershipRole.OWNER,
+    },
+  });
+
+  return res.status(200).json({ message: "User created successfully!" });
+}

--- a/apps/web/pages/api/webhook/funnelhub/funnelhub-signup.ts
+++ b/apps/web/pages/api/webhook/funnelhub/funnelhub-signup.ts
@@ -73,6 +73,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       teamId: userTeam.id,
       userId: user.id,
       role: MembershipRole.OWNER,
+      accepted: true,
     },
   });
 

--- a/apps/web/pages/api/webhook/funnelhub/funnelhub-user-exists/[id].ts
+++ b/apps/web/pages/api/webhook/funnelhub/funnelhub-user-exists/[id].ts
@@ -1,0 +1,29 @@
+/* eslint-disable turbo/no-undeclared-env-vars */
+import type { NextApiRequest, NextApiResponse } from "next";
+import { z } from "zod";
+
+import prisma from "@calcom/prisma";
+
+export const FunnelhubUserExistsSchema = z.object({
+  funnelHubUserId: z.string(),
+});
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const funnelHubToken = process.env.FUNNELHUB_API_TOKEN;
+  const funnelHubApiToken = req.headers["funnehub-calendar-token"];
+  const isFunnelHubOrigin = funnelHubToken === funnelHubApiToken;
+
+  if (req.method.toLowerCase() !== "get") return res.status(404).json({ message: "method not allowed" });
+
+  if (!isFunnelHubOrigin) return res.status(401).json({ message: "Invalid funnelhub api token " });
+
+  const userValidation = FunnelhubUserExistsSchema.safeParse({ funnelHubUserId: req.url?.split("/").pop() });
+
+  if (!userValidation.success)
+    return res.status(422).json({ errors: userValidation.error.flatten().fieldErrors });
+
+  const { funnelHubUserId } = userValidation.data;
+  const user = await prisma.user.findFirst({ where: { funnelHubUserId } });
+
+  return res.status(200).json({ exists: !!user });
+}

--- a/apps/web/pages/availability/index.tsx
+++ b/apps/web/pages/availability/index.tsx
@@ -182,7 +182,7 @@ export default function AvailabilityPage() {
               }}
               options={[
                 { value: "mine", label: t("my_availability") },
-                // { value: "team", label: t("team_availability") },
+                { value: "team", label: t("team_availability") },
               ]}
             />
             <NewScheduleButton />

--- a/apps/web/pages/insights/index.tsx
+++ b/apps/web/pages/insights/index.tsx
@@ -13,7 +13,6 @@ import { FiltersProvider } from "@calcom/features/insights/context/FiltersProvid
 import { Filters } from "@calcom/features/insights/filters";
 import { ShellMain } from "@calcom/features/shell/Shell";
 import { UpgradeTip } from "@calcom/features/tips";
-import { WEBAPP_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc";
 import { Button, ButtonGroup } from "@calcom/ui";
@@ -57,9 +56,9 @@ export default function InsightsPage() {
           buttons={
             <div className="space-y-2 rtl:space-x-reverse sm:space-x-2">
               <ButtonGroup>
-                <Button color="primary" href={`${WEBAPP_URL}/settings/teams/new`}>
+                {/* <Button color="primary" href={`${WEBAPP_URL}/settings/teams/new`}>
                   {t("create_team")}
-                </Button>
+                </Button> */}
                 <Button color="minimal" href="https://go.cal.com/insights" target="_blank">
                   {t("learn_more")}
                 </Button>

--- a/apps/web/pages/teams/index.tsx
+++ b/apps/web/pages/teams/index.tsx
@@ -3,11 +3,8 @@
 import { getLayout } from "@calcom/features/MainLayout";
 import { TeamsListing } from "@calcom/features/ee/teams/components";
 import { ShellMain } from "@calcom/features/shell/Shell";
-import { WEBAPP_URL } from "@calcom/lib/constants";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import { trpc } from "@calcom/trpc/react";
-import { Button } from "@calcom/ui";
-import { Plus } from "@calcom/ui/components/icon";
 
 import PageWrapper from "@components/PageWrapper";
 
@@ -22,18 +19,19 @@ function Teams() {
       heading={t("teams")}
       hideHeadingOnMobile
       subtitle={t("create_manage_teams_collaborative")}
-      CTA={
-        (!user.organizationId || user.organization.isOrgAdmin) && (
-          <Button
-            data-testid="new-team-btn"
-            variant="fab"
-            StartIcon={Plus}
-            type="button"
-            href={`${WEBAPP_URL}/settings/teams/new?returnTo=${WEBAPP_URL}/teams`}>
-            {t("new")}
-          </Button>
-        )
-      }>
+      // CTA={
+      //   (!user.organizationId || user.organization.isOrgAdmin) && (
+      //     <Button
+      //       data-testid="new-team-btn"
+      //       variant="fab"
+      //       StartIcon={Plus}
+      //       type="button"
+      //       href={`${WEBAPP_URL}/settings/teams/new?returnTo=${WEBAPP_URL}/teams`}>
+      //       {t("new")}
+      //     </Button>
+      //   )
+      // }>
+    >
       <TeamsListing />
     </ShellMain>
   );

--- a/packages/features/ee/organizations/pages/settings/other-team-members-view.tsx
+++ b/packages/features/ee/organizations/pages/settings/other-team-members-view.tsx
@@ -13,7 +13,6 @@ import { MembershipRole } from "@calcom/prisma/enums";
 import { trpc } from "@calcom/trpc/react";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import { Meta, showToast, Button } from "@calcom/ui";
-import { Plus } from "@calcom/ui/components/icon";
 
 import { getLayout } from "../../../../settings/layouts/SettingsLayout";
 import MakeTeamPrivateSwitch from "../../../teams/components/MakeTeamPrivateSwitch";
@@ -149,21 +148,21 @@ const MembersView = () => {
       <Meta
         title={t("team_members")}
         description={t("members_team_description")}
-        CTA={
-          isOrgAdminOrOwner ? (
-            <Button
-              type="button"
-              color="primary"
-              StartIcon={Plus}
-              className="ml-auto"
-              onClick={() => setShowMemberInvitationModal(true)}
-              data-testid="new-member-button">
-              {t("add")}
-            </Button>
-          ) : (
-            <></>
-          )
-        }
+        // CTA={
+        //   isOrgAdminOrOwner ? (
+        //     <Button
+        //       type="button"
+        //       color="primary"
+        //       StartIcon={Plus}
+        //       className="ml-auto"
+        //       onClick={() => setShowMemberInvitationModal(true)}
+        //       data-testid="new-member-button">
+        //       {t("add")}
+        //     </Button>
+        //   ) : (
+        //     <></>
+        //   )
+        // }
       />
       {!isPending && (
         <>

--- a/packages/features/ee/teams/components/MemberListItem.tsx
+++ b/packages/features/ee/teams/components/MemberListItem.tsx
@@ -1,5 +1,4 @@
 import classNames from "classnames";
-import { SendIcon } from "lucide-react";
 import { signIn } from "next-auth/react";
 import { useState } from "react";
 
@@ -21,13 +20,12 @@ import {
   DropdownItem,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
   showToast,
   Tooltip,
 } from "@calcom/ui";
 import { UserAvatar } from "@calcom/ui";
-import { ExternalLink, MoreHorizontal, Edit2, Lock, UserX } from "@calcom/ui/components/icon";
+import { ExternalLink, MoreHorizontal, Edit2, UserX } from "@calcom/ui/components/icon";
 
 import MemberChangeRoleModal from "./MemberChangeRoleModal";
 import TeamAvailabilityModal from "./TeamAvailabilityModal";
@@ -212,7 +210,7 @@ export default function MemberListItem(props: Props) {
                   />
                 </Tooltip>
               )}
-              {editMode && (
+              {/* {editMode && (
                 <Dropdown>
                   <DropdownMenuTrigger asChild>
                     <Button
@@ -271,7 +269,7 @@ export default function MemberListItem(props: Props) {
                     </DropdownMenuItem>
                   </DropdownMenuContent>
                 </Dropdown>
-              )}
+              )} */}
             </ButtonGroup>
             <div className="flex md:hidden">
               <Dropdown>

--- a/packages/features/ee/teams/components/TeamList.tsx
+++ b/packages/features/ee/teams/components/TeamList.tsx
@@ -4,7 +4,7 @@ import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import { trpc } from "@calcom/trpc/react";
 import { Card, showToast } from "@calcom/ui";
-import { UserPlus, Users, Edit } from "@calcom/ui/components/icon";
+import { Users, Edit } from "@calcom/ui/components/icon";
 
 import TeamListItem from "./TeamListItem";
 
@@ -65,7 +65,7 @@ export default function TeamList(props: Props) {
                 <div className="bg-subtle p-6">
                   <h3 className="text-emphasis mb-4 text-sm font-semibold">{t("recommended_next_steps")}</h3>
                   <div className="grid-col-1 grid gap-2 md:grid-cols-3">
-                    <Card
+                    {/* <Card
                       icon={<UserPlus className="h-5 w-5 text-green-700" />}
                       variant="basic"
                       title={t("invite_team_member")}
@@ -74,7 +74,7 @@ export default function TeamList(props: Props) {
                         href: `/settings/teams/${team.id}/members`,
                         child: t("invite"),
                       }}
-                    />
+                    /> */}
                     <Card
                       icon={<Users className="h-5 w-5 text-orange-700" />}
                       variant="basic"

--- a/packages/features/ee/teams/components/TeamListItem.tsx
+++ b/packages/features/ee/teams/components/TeamListItem.tsx
@@ -17,9 +17,6 @@ import {
   Badge,
   Button,
   ButtonGroup,
-  ConfirmationDialogContent,
-  Dialog,
-  DialogTrigger,
   Dropdown,
   DropdownItem,
   DropdownMenuContent,
@@ -35,10 +32,7 @@ import {
   ExternalLink,
   Globe,
   Link as LinkIcon,
-  LogOut,
   MoreHorizontal,
-  Send,
-  Trash,
   X,
 } from "@calcom/ui/components/icon";
 
@@ -291,7 +285,7 @@ export default function TeamListItem(props: Props) {
                         </DropdownItem>
                       </DropdownMenuItem>
                     )}
-                    {isAdmin && (
+                    {/* {isAdmin && (
                       <DropdownMenuItem>
                         <DropdownItem
                           type="button"
@@ -302,9 +296,9 @@ export default function TeamListItem(props: Props) {
                           {t("invite_team_member") as string}
                         </DropdownItem>
                       </DropdownMenuItem>
-                    )}
+                    )} */}
                     <DropdownMenuSeparator />
-                    {isOwner && (
+                    {/* {isOwner && (
                       <DropdownMenuItem>
                         <Dialog open={hideDropdown} onOpenChange={setHideDropdown}>
                           <DialogTrigger asChild>
@@ -330,9 +324,9 @@ export default function TeamListItem(props: Props) {
                           </ConfirmationDialogContent>
                         </Dialog>
                       </DropdownMenuItem>
-                    )}
+                    )} */}
 
-                    {!isOwner && (
+                    {/* {!isOwner && (
                       <DropdownMenuItem>
                         <Dialog>
                           <DialogTrigger asChild>
@@ -355,7 +349,7 @@ export default function TeamListItem(props: Props) {
                           </ConfirmationDialogContent>
                         </Dialog>
                       </DropdownMenuItem>
-                    )}
+                    )} */}
                   </DropdownMenuContent>
                 </Dropdown>
               </ButtonGroup>

--- a/packages/features/ee/teams/components/TeamsListing.tsx
+++ b/packages/features/ee/teams/components/TeamsListing.tsx
@@ -108,9 +108,9 @@ export function TeamsListing() {
           !user?.organizationId || user?.organization.isOrgAdmin ? (
             <div className="space-y-2 rtl:space-x-reverse sm:space-x-2">
               <ButtonGroup>
-                <Button color="primary" href={`${WEBAPP_URL}/settings/teams/new`}>
+                {/* <Button color="primary" href={`${WEBAPP_URL}/settings/teams/new`}>
                   {t("create_team")}
-                </Button>
+                </Button> */}
                 <Button color="minimal" href="https://go.cal.com/teams-video" target="_blank">
                   {t("learn_more")}
                 </Button>

--- a/packages/features/ee/teams/pages/team-members-view.tsx
+++ b/packages/features/ee/teams/pages/team-members-view.tsx
@@ -10,8 +10,7 @@ import { useParamsWithFallback } from "@calcom/lib/hooks/useParamsWithFallback";
 import { MembershipRole } from "@calcom/prisma/enums";
 import type { RouterOutputs } from "@calcom/trpc/react";
 import { trpc } from "@calcom/trpc/react";
-import { Button, Meta, showToast, TextField } from "@calcom/ui";
-import { Plus } from "@calcom/ui/components/icon";
+import { Meta, showToast, TextField } from "@calcom/ui";
 
 import { getLayout } from "../../../settings/layouts/SettingsLayout";
 import DisableTeamImpersonation from "../components/DisableTeamImpersonation";
@@ -142,21 +141,21 @@ const MembersView = () => {
       <Meta
         title={t("team_members")}
         description={t("members_team_description")}
-        CTA={
-          isAdmin || isOrgAdminOrOwner ? (
-            <Button
-              type="button"
-              color="primary"
-              StartIcon={Plus}
-              className="ml-auto"
-              onClick={() => setShowMemberInvitationModal(true)}
-              data-testid="new-member-button">
-              {t("add")}
-            </Button>
-          ) : (
-            <></>
-          )
-        }
+        // CTA={
+        //   isAdmin || isOrgAdminOrOwner ? (
+        //     <Button
+        //       type="button"
+        //       color="primary"
+        //       StartIcon={Plus}
+        //       className="ml-auto"
+        //       onClick={() => setShowMemberInvitationModal(true)}
+        //       data-testid="new-member-button">
+        //       {t("add")}
+        //     </Button>
+        //   ) : (
+        //     <></>
+        //   )
+        // }
       />
       {!isPending && (
         <>

--- a/packages/features/ee/teams/pages/team-profile-view.tsx
+++ b/packages/features/ee/teams/pages/team-profile-view.tsx
@@ -26,9 +26,6 @@ import { trpc } from "@calcom/trpc/react";
 import {
   Avatar,
   Button,
-  ConfirmationDialogContent,
-  Dialog,
-  DialogTrigger,
   Editor,
   Form,
   ImageUploader,
@@ -42,7 +39,7 @@ import {
   SkeletonAvatar,
   SkeletonButton,
 } from "@calcom/ui";
-import { ExternalLink, Link as LinkIcon, LogOut, Trash2 } from "@calcom/ui/components/icon";
+import { ExternalLink, Link as LinkIcon } from "@calcom/ui/components/icon";
 
 import { getLayout } from "../../../settings/layouts/SettingsLayout";
 
@@ -194,13 +191,13 @@ const ProfileView = () => {
         </div>
       )}
 
-      <div className="border-subtle mt-6 rounded-lg rounded-b-none border border-b-0 p-6">
+      {/* <div className="border-subtle mt-6 rounded-lg rounded-b-none border border-b-0 p-6">
         <Label className="mb-0 text-base font-semibold text-red-700">{t("danger_zone")}</Label>
         {team?.membership.role === "OWNER" && (
           <p className="text-subtle text-sm">{t("team_deletion_cannot_be_undone")}</p>
         )}
-      </div>
-      {team?.membership.role === "OWNER" ? (
+      </div> */}
+      {/* {team?.membership.role === "OWNER" ? (
         <Dialog>
           <SectionBottomActions align="end">
             <DialogTrigger asChild>
@@ -238,7 +235,7 @@ const ProfileView = () => {
             {t("leave_team_confirmation_message")}
           </ConfirmationDialogContent>
         </Dialog>
-      )}
+      )} */}
     </>
   );
 };

--- a/packages/features/kbar/Kbar.tsx
+++ b/packages/features/kbar/Kbar.tsx
@@ -163,13 +163,13 @@ export const KBarRoot = ({ children }: { children: React.ReactNode }) => {
         keywords: "change modify brand color",
         perform: () => router.push("/settings/my-account/appearance"),
       },
-      // {
-      //   id: "teams",
-      //   name: "teams",
-      //   shortcut: ["t", "s"],
-      //   keywords: "add manage modify team",
-      //   perform: () => router.push("/settings/teams"),
-      // },
+      {
+        id: "teams",
+        name: "teams",
+        shortcut: ["t", "s"],
+        keywords: "add manage modify team",
+        perform: () => router.push("/settings/teams"),
+      },
       // {
       //   id: "password",
       //   name: "change_password",

--- a/packages/features/settings/layouts/SettingsLayout.tsx
+++ b/packages/features/settings/layouts/SettingsLayout.tsx
@@ -8,7 +8,7 @@ import React, { Suspense, useEffect, useState } from "react";
 import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
 import Shell from "@calcom/features/shell/Shell";
 import { classNames } from "@calcom/lib";
-import { HOSTED_CAL_FEATURES, WEBAPP_URL } from "@calcom/lib/constants";
+import { HOSTED_CAL_FEATURES } from "@calcom/lib/constants";
 import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
 import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
@@ -24,7 +24,6 @@ import {
   Loader,
   Lock,
   Menu,
-  Plus,
   Terminal,
   User,
   Users,
@@ -100,12 +99,12 @@ const tabs: VerticalTabItemProps[] = [
       },
     ],
   },
-  // {
-  //   name: "teams",
-  //   href: "/teams",
-  //   icon: Users,
-  //   children: [],
-  // },
+  {
+    name: "teams",
+    href: "/teams",
+    icon: Users,
+    children: [],
+  },
   {
     name: "admin",
     href: "/settings/admin",
@@ -430,12 +429,12 @@ const SettingsSidebarContainer = ({
                                     {/* Hide if there is a parent ID */}
                                     {!team.parentId ? (
                                       <>
-                                        <VerticalTabItem
+                                        {/* <VerticalTabItem
                                           name={t("billing")}
                                           href={`/settings/teams/${team.id}/billing`}
                                           textClassNames="px-3 text-emphasis font-medium text-sm"
                                           disableChevron
-                                        />
+                                        /> */}
                                         {HOSTED_CAL_FEATURES && (
                                           <VerticalTabItem
                                             name={t("saml_config")}
@@ -452,7 +451,7 @@ const SettingsSidebarContainer = ({
                             </Collapsible>
                           );
                       })}
-                    {(!currentOrg || (currentOrg && currentOrg?.user?.role !== "MEMBER")) && (
+                    {/* {(!currentOrg || (currentOrg && currentOrg?.user?.role !== "MEMBER")) && (
                       <VerticalTabItem
                         name={t("add_a_team")}
                         href={`${WEBAPP_URL}/settings/teams/new`}
@@ -460,7 +459,7 @@ const SettingsSidebarContainer = ({
                         icon={Plus}
                         disableChevron
                       />
-                    )}
+                    )} */}
                   </div>
                 </React.Fragment>
               )}

--- a/packages/features/settings/layouts/SettingsLayoutAppDir.tsx
+++ b/packages/features/settings/layouts/SettingsLayoutAppDir.tsx
@@ -10,7 +10,7 @@ import React, { Suspense, useEffect, useState } from "react";
 import { useOrgBranding } from "@calcom/features/ee/organizations/context/provider";
 import Shell from "@calcom/features/shell/Shell";
 import { classNames } from "@calcom/lib";
-import { HOSTED_CAL_FEATURES, WEBAPP_URL } from "@calcom/lib/constants";
+import { HOSTED_CAL_FEATURES } from "@calcom/lib/constants";
 import { getPlaceholderAvatar } from "@calcom/lib/defaultAvatarImage";
 import { getUserAvatarUrl } from "@calcom/lib/getAvatarUrl";
 import { useCompatSearchParams } from "@calcom/lib/hooks/useCompatSearchParams";
@@ -28,7 +28,6 @@ import {
   Loader,
   Lock,
   Menu,
-  Plus,
   Terminal,
   User,
   Users,
@@ -103,12 +102,12 @@ const tabs: VerticalTabItemProps[] = [
       },
     ],
   },
-  // {
-  //   name: "teams",
-  //   href: "/teams",
-  //   icon: Users,
-  //   children: [],
-  // },
+  {
+    name: "teams",
+    href: "/teams",
+    icon: Users,
+    children: [],
+  },
   {
     name: "admin",
     href: "/settings/admin",
@@ -453,7 +452,7 @@ const SettingsSidebarContainer = ({
                             </Collapsible>
                           );
                       })}
-                    {(!currentOrg || (currentOrg && currentOrg?.user?.role !== "MEMBER")) && (
+                    {/* {(!currentOrg || (currentOrg && currentOrg?.user?.role !== "MEMBER")) && (
                       <VerticalTabItem
                         name={t("add_a_team")}
                         href={`${WEBAPP_URL}/settings/teams/new`}
@@ -461,7 +460,7 @@ const SettingsSidebarContainer = ({
                         icon={Plus}
                         disableChevron
                       />
-                    )}
+                    )} */}
                   </div>
                 </React.Fragment>
               )}

--- a/packages/features/shell/Shell.tsx
+++ b/packages/features/shell/Shell.tsx
@@ -77,10 +77,12 @@ import {
   MoreHorizontal,
   Settings,
   User as UserIcon,
+  Users,
 } from "@calcom/ui/components/icon";
 
 import { useOrgBranding } from "../ee/organizations/context/provider";
 import FreshChatProvider from "../ee/support/lib/freshchat/FreshChatProvider";
+import { TeamInviteBadge } from "./TeamInviteBadge";
 
 // need to import without ssr to prevent hydration errors
 const Tips = dynamic(() => import("@calcom/features/tips").then((mod) => mod.Tips), {
@@ -519,13 +521,13 @@ const navigation: NavigationItemType[] = [
     href: "/availability",
     icon: Clock,
   },
-  // {
-  //   name: "teams",
-  //   href: "/teams",
-  //   icon: Users,
-  //   onlyDesktop: true,
-  //   badge: <TeamInviteBadge />,
-  // },
+  {
+    name: "teams",
+    href: "/teams",
+    icon: Users,
+    onlyDesktop: true,
+    badge: <TeamInviteBadge />,
+  },
   {
     name: "apps",
     href: "/apps",

--- a/packages/features/timezone-buddy/components/AvailabilitySliderTable.tsx
+++ b/packages/features/timezone-buddy/components/AvailabilitySliderTable.tsx
@@ -4,7 +4,7 @@ import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import { useMemo, useRef, useCallback, useEffect, useState } from "react";
 
 import dayjs from "@calcom/dayjs";
-import { APP_NAME, WEBAPP_URL } from "@calcom/lib/constants";
+import { APP_NAME } from "@calcom/lib/constants";
 import type { DateRange } from "@calcom/lib/date-ranges";
 import { useLocale } from "@calcom/lib/hooks/useLocale";
 import type { MembershipRole } from "@calcom/prisma/enums";
@@ -42,9 +42,9 @@ function UpgradeTeamTip() {
       buttons={
         <div className="space-y-2 rtl:space-x-reverse sm:space-x-2">
           <ButtonGroup>
-            <Button color="primary" href={`${WEBAPP_URL}/settings/teams/new`}>
+            {/* <Button color="primary" href={`${WEBAPP_URL}/settings/teams/new`}>
               {t("create_team")}
-            </Button>
+            </Button> */}
             <Button color="minimal" href="https://go.cal.com/teams-video" target="_blank">
               {t("learn_more")}
             </Button>

--- a/packages/prisma/.env
+++ b/packages/prisma/.env
@@ -1,1 +1,2 @@
+DATABASE_URL="postgresql://postgres:@localhost:5450/calendso"
 ../../.env

--- a/packages/prisma/migrations/20240405170603_add_workspace_funnelhub_id/migration.sql
+++ b/packages/prisma/migrations/20240405170603_add_workspace_funnelhub_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Team" ADD COLUMN     "funnelhubWorkspaceId" TEXT;

--- a/packages/prisma/schema.prisma
+++ b/packages/prisma/schema.prisma
@@ -320,6 +320,7 @@ model Team {
   accessCodes          AccessCode[]
   instantMeetingTokens InstantMeetingToken[]
   pendingPayment       Boolean                 @default(false)
+  funnelhubWorkspaceId String?
 
   @@unique([slug, parentId])
 }


### PR DESCRIPTION
## What does this PR do?

Adição de uma api "funnelhub" para o gerenciamento de membros de times e criação de usuários, assim fica mais centralizado

- Criação de rotas de adição e deleção de membros
- Criação de rota de checagem se existe um usuário com um funnelhub id cadastrado no calcom
- Melhoria na rota de criação de usuário do cal via funnelhub para criar tanto membros que n possuem contas quanto donos de "workspaces", criação de um time quando um usuário root é criado no calcom
- Descomentei a feature de times e removi alguns botões de gerenciamento de membros pois o nosso gerenciamento será feito com base no hub
